### PR TITLE
added env for scope

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -55,7 +55,7 @@ return [
     |
     */
 
-    'scopes' => 'identify&email',
+    'scopes' => env('LARASCORD_SCOPE', 'identify&email'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Cause there is no `env()` function used in larascord.php at the scope section, the line from the `.env` would complete ignored.