### PR TITLE
Fix default stack issue when installing laravel/breeze without specifying a stack

### DIFF
--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -243,6 +243,7 @@ class InstallCommand extends Command
             ->run(function ($type, $output) {
                 if ($type === Process::ERR) {
                     $this->error(trim($output));
+                    exit(1);
                 } else {
                     $this->output->write($output);
                 }

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -50,9 +50,9 @@ class InstallCommand extends Command
         $this->info('Installing Larascord...');
         $this->requireComposerPackages('laravel/breeze:^1.18', '-q');
         if ($this->darkMode) {
-            shell_exec('php artisan breeze:install --dark');
+            shell_exec('php artisan breeze:install blade --dark');
         } else {
-            shell_exec('php artisan breeze:install');
+            shell_exec('php artisan breeze:install blade');
         }
 
         // Appending the secrets to the .env file

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -48,7 +48,7 @@ class InstallCommand extends Command
 
         // Installing laravel/breeze
         $this->info('Installing Larascord...');
-        $this->requireComposerPackages('laravel/breeze:^1.16', '-q');
+        $this->requireComposerPackages('laravel/breeze:^1.18', '-q');
         if ($this->darkMode) {
             shell_exec('php artisan breeze:install --dark');
         } else {

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -240,10 +240,9 @@ class InstallCommand extends Command
 
         (new Process($command, base_path(), ['COMPOSER_MEMORY_LIMIT' => '-1']))
             ->setTimeout(null)
-            ->run(function ($type, $output) use ($packages) {
+            ->run(function ($type, $output) {
                 if ($type === Process::ERR) {
                     $this->error(trim($output));
-                    exit(1);
                 } else {
                     $this->output->write($output);
                 }

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -240,8 +240,13 @@ class InstallCommand extends Command
 
         (new Process($command, base_path(), ['COMPOSER_MEMORY_LIMIT' => '-1']))
             ->setTimeout(null)
-            ->run(function ($type, $output) {
-                $this->output->write($output);
+            ->run(function ($type, $output) use ($packages) {
+                if ($type === Process::ERR) {
+                    $this->error(trim($output));
+                    exit(1);
+                } else {
+                    $this->output->write($output);
+                }
             });
     }
 


### PR DESCRIPTION
It appears that the issue is a result of a recent update to the [laravel/breeze](https://github.com/laravel/breeze/) package.

Prior to this update, when using the command `php artisan breeze:install` without specifying a stack (i.e. blade, vue, react, etc.), it would default to the `blade` stack. However, as per the commit located at https://github.com/laravel/breeze/commit/66a65c5a38ab219da32a00cfa6d10fef162c006e, this feature has been removed.

As such, if no stack is specified, the user will be prompted to make a selection (https://github.com/laravel/breeze/blob/1.x/src/Console/InstallCommand.php#L84). As the [laravel/breeze](https://github.com/laravel/breeze/) package is installed using the -q (quiet) flag, this will prevent the prompt from being displayed, basically pausing the install process forever.

This pull request fixes #46 