### PR TITLE
Hotfix DiscordAccessToken model

### DIFF
--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -190,7 +190,7 @@ class InstallCommand extends Command
     public function createModelFiles(): void
     {
         (new Filesystem())->ensureDirectoryExists(app_path('Models'));
-        (new Filesystem())->copyDirectory(__DIR__ . '/../../Models/', app_path('Models/'));
+        (new Filesystem())->copy(__DIR__ . '/../../Models/User.php', app_path('Models/User.php'));
     }
 
     /**

--- a/src/Models/DiscordAccessToken.php
+++ b/src/Models/DiscordAccessToken.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace Jakyeru\Larascord\Models;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/src/Traits/InteractsWithDiscord.php
+++ b/src/Traits/InteractsWithDiscord.php
@@ -2,7 +2,7 @@
 
 namespace Jakyeru\Larascord\Traits;
 
-use App\Models\DiscordAccessToken;
+use Jakyeru\Larascord\Models\DiscordAccessToken;
 use Exception;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Http\Client\RequestException;


### PR DESCRIPTION
This PR will only copy the User model to `App\Models`.