### PR TITLE
Hotfix remove unnecessary scopes from config

### DIFF
--- a/src/LarascordServiceProvider.php
+++ b/src/LarascordServiceProvider.php
@@ -11,7 +11,7 @@ class LarascordServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    const VERSION = '5.0.2';
+    const VERSION = '5.0.3';
 
     /*
      * Register the application services.

--- a/src/Services/DiscordService.php
+++ b/src/Services/DiscordService.php
@@ -157,7 +157,7 @@ class DiscordService
     public function joinGuild(AccessToken $accessToken, User $user, string $guildId, array $options = []): GuildMember
     {
         if (!config('larascord.access_token')) throw new Exception(config('larascord.error_messages.missing_access_token.message'));
-        if (!$accessToken->hasScope('guilds.join')) throw new Exception(config('larascord.error_messages.missing_guilds_join_scope.message'));
+        if (!$accessToken->hasScope('guilds.join')) throw new Exception('The "guilds" and "guilds.join" scopes are required.');
 
         $response = Http::withToken(config('larascord.access_token'), 'Bot')->put($this->baseApi . '/guilds/' . $guildId . '/members/' . $user->id, array_merge([
             'access_token' => $accessToken->access_token,

--- a/src/Services/DiscordService.php
+++ b/src/Services/DiscordService.php
@@ -137,7 +137,7 @@ class DiscordService
      */
     public function getCurrentUserConnections(AccessToken $accessToken): array
     {
-        if (!$accessToken->hasScope('connections')) throw new Exception(config('larascord.error_messages.missing_connections_scope.message'));
+        if (!$accessToken->hasScope('connections')) throw new Exception('The "connections" scope is required.');
 
         $response = Http::withToken($accessToken->access_token, $accessToken->token_type)->get($this->baseApi . '/users/@me/connections');
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -201,10 +201,6 @@ return [
             'message' => 'The "guilds" and "guilds.members.read" scopes are required.',
             'redirect' => '/'
         ],
-        'missing_guilds_join_scope' => [
-            'message' => 'The "guilds" and "guilds.join" scopes are required.',
-            'redirect' => '/'
-        ],
         'missing_connections_scope' => [
             'message' => 'The "connections" scope is required.',
             'redirect' => '/'

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -201,10 +201,6 @@ return [
             'message' => 'The "guilds" and "guilds.members.read" scopes are required.',
             'redirect' => '/'
         ],
-        'missing_connections_scope' => [
-            'message' => 'The "connections" scope is required.',
-            'redirect' => '/'
-        ],
         'authorization_failed_guilds' => [
             'message' => 'Couldn\'t get the servers you\'re in.',
             'redirect' => '/'


### PR DESCRIPTION
These scopes were only used in `DiscordService.php`, therefore it would only throw the error message and not redirect.