### PR TITLE
Feat: Guild Member Counts Closes #112

### DIFF
--- a/docs/pages/interacts_with_discord.mdx
+++ b/docs/pages/interacts_with_discord.mdx
@@ -83,8 +83,11 @@ try {
     This method will make a request to Discord's API. It is recommended to cache the response.
 </Callout>
 <Callout type="info">
-    This method accepts a type "bool" as a parameter, true will return member counts.
+    The `withCounts` parameter is optional.
 </Callout>
+| Parameter     | Type   | Description                    |
+|:--------------|:-------|:-------------------------------|
+| withCounts    | bool   | Include member counts          |
 ```php copy=false
 /**
 * Returns the user's guilds from Discord's API.

--- a/docs/pages/interacts_with_discord.mdx
+++ b/docs/pages/interacts_with_discord.mdx
@@ -121,6 +121,54 @@ try {
  }
 ```
 
+## getGuildsWithMemberCounts
+<Callout type="warning">
+    This method will make a request to Discord's API. It is recommended to cache the response.
+</Callout>
+<Callout type="info">
+    This method will retrieve all of the same information as the "getGuilds" method. This method only adds the approximate member counts, and approximate presence counts to the response.
+</Callout>
+```php copy=false
+/**
+* Returns the user's guilds from Discord's API.
+*
+* @return Illuminate\Support\Collection
+* @throws Illuminate\Http\Client\RequestException
+* @throws Exception
+*/
+```
+
+### Example
+```php showLineNumbers
+use \Illuminate\Support\Facades\Log;
+
+$user = auth()->user();
+
+try {
+    $guilds = $user->getGuildsWithMemberCounts();
+
+    Log::info(json_encode($guilds->first()));
+    /*
+      {
+        "id": "81384788765712384",
+        "name": "Discord API",
+        "icon": "a363a84e969bcbe1353eb2fdfb2e50e6",
+        "owner": false,
+        "permissions": 104189632,
+        "features": [
+          "ANIMATED_ICON",
+          "INVITE_SPLASH"
+        ],
+        "permissions_new": "110917634608832",
+        "approximate_member_count": 451,
+        "approximate_presence_count": 246
+      }
+    */
+ } catch (\Exception $exception) {
+    Log::error('Something went wrong.');
+ }
+```
+
 ## getGuildMember
 <Callout type="warning">
     This method will make a request to Discord's API. It is recommended to cache the response.

--- a/docs/pages/interacts_with_discord.mdx
+++ b/docs/pages/interacts_with_discord.mdx
@@ -82,12 +82,6 @@ try {
 <Callout type="warning">
     This method will make a request to Discord's API. It is recommended to cache the response.
 </Callout>
-<Callout type="info">
-    The `withCounts` parameter is optional.
-</Callout>
-| Parameter     | Type   | Description                    |
-|:--------------|:-------|:-------------------------------|
-| withCounts    | bool   | Include member counts          |
 ```php copy=false
 /**
 * Returns the user's guilds from Discord's API.
@@ -97,6 +91,14 @@ try {
 * @throws Exception
 */
 ```
+
+### Parameters
+<Callout type="info">
+    The `withCounts` parameter is optional.
+</Callout>
+| Parameter     | Type   | Description                    |
+|:--------------|:-------|:-------------------------------|
+| withCounts    | bool   | Include member counts          |
 
 ### Example
 ```php showLineNumbers

--- a/docs/pages/interacts_with_discord.mdx
+++ b/docs/pages/interacts_with_discord.mdx
@@ -82,51 +82,8 @@ try {
 <Callout type="warning">
     This method will make a request to Discord's API. It is recommended to cache the response.
 </Callout>
-```php copy=false
-/**
-* Returns the user's guilds from Discord's API.
-*
-* @return Illuminate\Support\Collection
-* @throws Illuminate\Http\Client\RequestException
-* @throws Exception
-*/
-```
-
-### Example
-```php showLineNumbers
-use \Illuminate\Support\Facades\Log;
-
-$user = auth()->user();
-
-try {
-    $guilds = $user->getGuilds();
-
-    Log::info(json_encode($guilds->first()));
-    /*
-      {
-        "id": "81384788765712384",
-        "name": "Discord API",
-        "icon": "a363a84e969bcbe1353eb2fdfb2e50e6",
-        "owner": false,
-        "permissions": 104189632,
-        "features": [
-          "ANIMATED_ICON",
-          "INVITE_SPLASH"
-        ],
-        "permissions_new": "110917634608832"
-      }
-    */
- } catch (\Exception $exception) {
-    Log::error('Something went wrong.');
- }
-```
-
-## getGuildsWithMemberCounts
-<Callout type="warning">
-    This method will make a request to Discord's API. It is recommended to cache the response.
-</Callout>
 <Callout type="info">
-    This method will retrieve all of the same information as the "getGuilds" method. This method only adds the approximate member counts, and approximate presence counts to the response.
+    This method accepts a type "bool" as a parameter, true will return member counts.
 </Callout>
 ```php copy=false
 /**
@@ -145,7 +102,7 @@ use \Illuminate\Support\Facades\Log;
 $user = auth()->user();
 
 try {
-    $guilds = $user->getGuildsWithMemberCounts();
+    $guilds = $user->getGuilds(true);
 
     Log::info(json_encode($guilds->first()));
     /*
@@ -160,8 +117,8 @@ try {
           "INVITE_SPLASH"
         ],
         "permissions_new": "110917634608832",
-        "approximate_member_count": 451,
-        "approximate_presence_count": 246
+        "approximate_member_count": 425,
+        "approximate_presence_count": 312
       }
     */
  } catch (\Exception $exception) {

--- a/src/Services/DiscordService.php
+++ b/src/Services/DiscordService.php
@@ -99,29 +99,7 @@ class DiscordService
      * @throws RequestException
      * @throws Exception
      */
-    public function getCurrentUserGuilds(AccessToken $accessToken): array
-    {
-        return $this->fetchUserGuildsWithOptionalCounts($accessToken);
-    }
-
-    /**
-    * Get the user's guilds with member counts.
-    *
-    * @throws RequestException
-    * @throws Exception
-    */
-    public function getCurrentUserGuildsWithMemberCounts(AccessToken $accessToken): array
-    {
-        return $this->fetchUserGuildsWithOptionalCounts($accessToken, true);
-    }
-
-    /**
-    * Helper method to fetch user's guilds.
-    *
-    * @throws Request Exception
-    * @throws Exception
-    */
-    private function fetchUserGuildsWithOptionalCounts(AccessToken $accessToken, bool $withCounts = false): array
+    public function getCurrentUserGuilds(AccessToken $accessToken, bool $withCounts = false): array
     {
         if (!$accessToken->hasScope('guilds')) throw new Exception(config('larascord.error_messages.missing_guilds_scope.message'));
 

--- a/src/Services/DiscordService.php
+++ b/src/Services/DiscordService.php
@@ -101,9 +101,37 @@ class DiscordService
      */
     public function getCurrentUserGuilds(AccessToken $accessToken): array
     {
+        return $this->fetchUserGuildsWithOptionalCounts($accessToken);
+    }
+
+    /**
+    * Get the user's guilds with member counts.
+    *
+    * @throws RequestException
+    * @throws Exception
+    */
+    public function getCurrentUserGuildsWithMemberCounts(AccessToken $accessToken): array
+    {
+        return $this->fetchUserGuildsWithOptionalCounts($accessToken, true);
+    }
+
+    /**
+    * Helper method to fetch user's guilds.
+    *
+    * @throws Request Exception
+    * @throws Exception
+    */
+    private function fetchUserGuildsWithOptionalCounts(AccessToken $accessToken, bool $withCounts = false): array
+    {
         if (!$accessToken->hasScope('guilds')) throw new Exception(config('larascord.error_messages.missing_guilds_scope.message'));
 
-        $response = Http::withToken($accessToken->access_token, $accessToken->token_type)->get($this->baseApi . '/users/@me/guilds');
+        $endpoint = '/users/@me/guilds';
+
+        if ($withCounts) {
+            $endpoint .= '?with_counts=true';
+        }
+
+        $response = Http::withToken($accessToken->access_token, $accessToken->token_type)->get($this->baseApi . $endpoint);
 
         $response->throw();
 

--- a/src/Traits/InteractsWithDiscord.php
+++ b/src/Traits/InteractsWithDiscord.php
@@ -95,6 +95,25 @@ trait InteractsWithDiscord
     }
 
     /**
+    * Get the user's guilds with member counts.
+    *
+    * @throws RequestException
+    * @throws Exception
+    */
+    public function getGuildsWithMemberCounts(): Collection
+    {
+        $accessToken = $this->getAccessToken();
+
+        if (!$accessToken) {
+            throw new Exception('The access token is invalid.');
+        }
+
+        $response = (new DiscordService())->getCurrentUserGuildsWithMemberCounts($accessToken);
+
+        return collect($response);
+    }
+
+    /**
      * Get the user's guild member.
      *
      * @throws RequestException

--- a/src/Traits/InteractsWithDiscord.php
+++ b/src/Traits/InteractsWithDiscord.php
@@ -81,7 +81,7 @@ trait InteractsWithDiscord
      * @throws RequestException
      * @throws Exception
      */
-    public function getGuilds(): Collection
+    public function getGuilds(bool $withCounts = false): Collection
     {
         $accessToken = $this->getAccessToken();
 
@@ -89,26 +89,7 @@ trait InteractsWithDiscord
             throw new Exception('The access token is invalid.');
         }
 
-        $response = (new DiscordService())->getCurrentUserGuilds($accessToken);
-
-        return collect($response);
-    }
-
-    /**
-    * Get the user's guilds with member counts.
-    *
-    * @throws RequestException
-    * @throws Exception
-    */
-    public function getGuildsWithMemberCounts(): Collection
-    {
-        $accessToken = $this->getAccessToken();
-
-        if (!$accessToken) {
-            throw new Exception('The access token is invalid.');
-        }
-
-        $response = (new DiscordService())->getCurrentUserGuildsWithMemberCounts($accessToken);
+        $response = (new DiscordService())->getCurrentUserGuilds($accessToken, $withCounts);
 
         return collect($response);
     }

--- a/src/Types/Guild.php
+++ b/src/Types/Guild.php
@@ -63,7 +63,7 @@ class Guild
         $this->permissions = $data->permissions;
         $this->features = $data->features;
         $this->permissions_new = $data->permissions_new;
-        $this->approximate_member_count = $data->approximate_member_count;
-        $this->approximate_presence_count = $data->approximate_presence_count;
+        $this->approximate_member_count = $data->approximate_member_count ?? null;
+        $this->approximate_presence_count = $data->approximate_presence_count ?? null;
     }
 }

--- a/src/Types/Guild.php
+++ b/src/Types/Guild.php
@@ -42,6 +42,16 @@ class Guild
     public string $permissions_new;
 
     /*
+    * The approximate count of members in the guild.
+    */
+    public ?int $approximate_member_count;
+
+    /*
+    * The approximate count of active members in the guild.
+    */
+    public ?int $approximate_presence_count;
+
+    /*
      * Guild constructor.
      */
     public function __construct(object $data)
@@ -53,5 +63,7 @@ class Guild
         $this->permissions = $data->permissions;
         $this->features = $data->features;
         $this->permissions_new = $data->permissions_new;
+        $this->approximate_member_count = $data->approximate_member_count;
+        $this->approximate_presence_count = $data->approximate_presence_count;
     }
 }


### PR DESCRIPTION
## Description
Added functionality to fetch Guild's approximate member counts, and approximate member presence.

## Related Issue
Closes #112 

## Changes Made

- Added approximate member counts, and approximate presence in the Guild Type.
- Added a method in DiscordService to fetch guilds with member counts.
- Added getGuildsWithMemberCounts method to InteractsWithDiscord.
- Adjusted Interacts_with_discord.mdx documentation to explain the new getGuildsWithMemberCounts method.

## Checklist
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate documentation or updated existing documentation (if applicable).
- [x] I have ensured that my code follows the project's coding guidelines.
- [x] I have added necessary tests to cover the changes (if applicable).
- [x] I have rebased my branch onto the latest master/main branch.
- [x] I have resolved any merge conflicts that may arise.
- [x] I have reviewed and proofread my code for any errors or typos.

