### PR TITLE
Generate Avatar cdn method

### DIFF
--- a/docs/pages/interacts_with_discord.mdx
+++ b/docs/pages/interacts_with_discord.mdx
@@ -90,7 +90,7 @@ try {
 |:--------------|:-------|:--------|:--------------------------------------------------------------------------------------------------|
 | extension     | string | 'png'   | Accepted image extensions: 'png', 'jpg', 'jpeg', 'webp', 'gif'. Fallback image can only be 'png'. |
 | size          | int    | 128     | Image size can be any power of two between 16 and 4096. Fallback image will be 256.               |
-| color         | int    | random  | Color of fallback image: 0:blue 1:gray 2:green 3:orange 4:red 5:magenta                           |
+| color         | int    | random  | Color of fallback image: 0:blue 1:gray 2:green 3:orange 4:red 5:magenta.                          |
 
 ### Example
 ```php showLineNumbers
@@ -98,9 +98,9 @@ try {
 <img src="{{ Auth::user()->getAvatar('webp', 64, 2) }}" alt="{{ Auth::user()->getTagAttribute() }}" />
 /**
 * This will fetch the user's avatar with:
-* - webp extension (fallback image will be png)
-* - height and width of 64px (fallback image will 256x256)
-* - Color of the fallback image will be green
+* - webp extension (fallback image will be png).
+* - height and width of 64px (fallback image will 256x256).
+* - Color of the fallback image will be green.
 */
 ```
 

--- a/docs/pages/interacts_with_discord.mdx
+++ b/docs/pages/interacts_with_discord.mdx
@@ -78,6 +78,32 @@ try {
  }
 ```
 
+## getAvatar
+<Callout type="info">
+    This method generates the cdn url for user's avatars with a fallback image if the user does not have an avatar.
+</Callout>
+### Parameters
+<Callout type="info">
+    Parameters are optional.
+</Callout>
+| Parameter     | Type   | Default | Description                                                                                       |
+|:--------------|:-------|:--------|:--------------------------------------------------------------------------------------------------|
+| extension     | string | 'png'   | Accepted image extensions: 'png', 'jpg', 'jpeg', 'webp', 'gif'. Fallback image can only be 'png'. |
+| size          | int    | 128     | Image size can be any power of two between 16 and 4096. Fallback image will be 256.               |
+| color         | int    | random  | Color of fallback image: 0:blue 1:gray 2:green 3:orange 4:red 5:magenta                           |
+
+### Example
+```php showLineNumbers
+
+<img src="{{ Auth::user()->getAvatar('webp', 64, 2) }}" alt="{{ Auth::user()->getTagAttribute() }}" />
+/**
+* This will fetch the user's avatar with:
+* - webp extension (fallback image will be png)
+* - height and width of 64px (fallback image will 256x256)
+* - Color of the fallback image will be green
+*/
+```
+
 ## getGuilds
 <Callout type="warning">
     This method will make a request to Discord's API. It is recommended to cache the response.

--- a/src/Traits/InteractsWithDiscord.php
+++ b/src/Traits/InteractsWithDiscord.php
@@ -76,6 +76,22 @@ trait InteractsWithDiscord
     }
 
     /**
+    * Get the user's Avatar url
+    */
+    public function getAvatar(?string $extension = 'png', ?int $size = null, ?int $color = null): string
+    {
+        $baseUrl = 'https://cdn.discordapp.com/';
+        $sizeParam = $size ? "?size={$size}" : '';
+        $colorParam = $color ?? rand(0, 4);
+
+        if ($this->avatar) {
+            return "{$baseUrl}avatars/{$this->id}/{$this->avatar}.{$extension}{$sizeParam}";
+        }
+
+        return "{$baseUrl}embed/avatars/{$colorParam}.png";
+    }
+
+    /**
      * Get the user's guilds.
      *
      * @throws RequestException

--- a/src/Traits/InteractsWithDiscord.php
+++ b/src/Traits/InteractsWithDiscord.php
@@ -82,7 +82,7 @@ trait InteractsWithDiscord
     {
         $baseUrl = 'https://cdn.discordapp.com/';
         $sizeParam = $size ? "?size={$size}" : '';
-        $colorParam = $color ?? rand(0, 4);
+        $colorParam = $color ?? rand(0, 5);
 
         if ($this->avatar) {
             return "{$baseUrl}avatars/{$this->id}/{$this->avatar}.{$extension}{$sizeParam}";

--- a/src/resources/views/layouts/navigation.blade.php
+++ b/src/resources/views/layouts/navigation.blade.php
@@ -23,8 +23,8 @@
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
                         <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 focus:outline-none transition ease-in-out duration-150">
-                            @if(Auth::user()->avatar)
-                                <img class="h-8 w-8 rounded-full object-cover mr-2" src="https://cdn.discordapp.com/avatars/{{ Auth::user()->id }}/{{ Auth::user()->avatar }}.webp" alt="{{ Auth::user()->getTagAttribute() }}" />
+                            @if(Auth::user())
+                                <img class="h-8 w-8 rounded-full object-cover mr-2" src="{{Auth::user()->getAvatar('webp', 32)}}" alt="{{ Auth::user()->getTagAttribute() }}" />
                             @endif
 
                             <div style="display: flex; flex-direction: column; align-items: flex-start;">

--- a/src/resources/views/layouts/navigation.blade.php
+++ b/src/resources/views/layouts/navigation.blade.php
@@ -23,9 +23,7 @@
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
                         <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 focus:outline-none transition ease-in-out duration-150">
-                            @if(Auth::user())
-                                <img class="h-8 w-8 rounded-full object-cover mr-2" src="{{Auth::user()->getAvatar('webp', 32)}}" alt="{{ Auth::user()->getTagAttribute() }}" />
-                            @endif
+                            <img class="h-8 w-8 rounded-full object-cover mr-2" src="{{Auth::user()->getAvatar('webp', 32)}}" alt="{{ Auth::user()->getTagAttribute() }}" />
 
                             <div style="display: flex; flex-direction: column; align-items: flex-start;">
                                 {{ Auth::user()->getTagAttribute() }}


### PR DESCRIPTION
## Description
Added a method to generate the cdn for user's avatars.

## Related Issue
Closes #115 

## Changes Made

- Added getAvatar method to InteractsWithDiscord. This method returns a url for the user's avatar, and a fallback if no avatar is provided.
- Applied the getAvatar method to the navigation layout.
- Adjusted documentation to explain the getAvatar method

## Checklist
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate documentation or updated existing documentation (if applicable).
- [x] I have ensured that my code follows the project's coding guidelines.
- [x] I have added necessary tests to cover the changes (if applicable).
- [x] I have rebased my branch onto the latest master/main branch.
- [x] I have resolved any merge conflicts that may arise.
- [x] I have reviewed and proofread my code for any errors or typos.

## Additional Notes
There are no guild migrations, so I did not add a method to fetch guild icons.

